### PR TITLE
Update 2025-05.md

### DIFF
--- a/monthly-updates/2025-05.md
+++ b/monthly-updates/2025-05.md
@@ -91,7 +91,7 @@ Work is in progress, with much of the effort being directed to updating net80211
 GitHub issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/34 
 
 #### Intel WiFi followup tasks
-The recently completed [iwx support for WiFi 4 and 5 by Intel devices](monthly-updates/2025-03.md) will ship with basic 11ac STA support in 14.3. Remaining related issues are now being worked on. These include Suspend AND resume functionality, automatic rate selection for vht networks, resolve re-association issues, good defaults for networks, propagate regdomain updates, and hardware crypto offload.
+Issues related to the recently completed [iwx support for WiFi 4 and 5 by Intel devices](monthly-updates/2025-03.md) are now being worked on. These include Suspend AND resume functionality, automatic rate selection for vht networks, resolve re-association issues, good defaults for networks, propagate regdomain updates, and hardware crypto offload.
 
 GitHub issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/72 
 


### PR DESCRIPTION
Removing erroneous statement that iwx will be in 14.3 

@bzfbd and @emaste please merge this correction if it looks OK. 

Thanks to @bzfbd who spotted the error and let me know:

> "The recently completed iwx support for WiFi 4 and 5 by Intel devices
> will ship with basic 11ac STA support in 14.3. "
> 
> That is wrong;  there is no iwx even in stable/14 from Tom:
> 
> % git rebase -i freebsd/stable/14
> Successfully rebased and updated refs/heads/stable/14.
> % ls -l sys/dev/iwx
> ls: sys/dev/iwx: No such file or directory
> 
> It is iwlwifi that is shipping with 11ac in 14.3.
> 
> /zz