### PR TITLE
Small edits to June laptop report: 2025-06.md

### DIFF
--- a/monthly-updates/2025-06.md
+++ b/monthly-updates/2025-06.md
@@ -30,10 +30,6 @@ Prototype scheduler changes addressed the issue. The scheduler now always stays 
 
 GitHub issue: [#55](https://github.com/FreeBSDFoundation/proj-laptop/issues/55)
 
-### Laptop Project Q2 roadmap 
-The Foundation has reviewed and updated the Laptop Support and Usability Improvements Project roadmap. To see the Q2 roadmap document, please go to: 
-https://github.com/FreeBSDFoundation/proj-laptop/blob/main/monthly-updates/Q2-2025-roadmap.pdf 
-
 ## Progress updates
 
 ### Power Management
@@ -75,7 +71,7 @@ GitHub issue: [#34](https://github.com/FreeBSDFoundation/proj-laptop/issues/34)
 #### Intel WiFi Followup Tasks
 Suspend and resume functionality for iwx was committed in June. Improvements during association to best take advantage of network rates and automatically select the correct regdomain are still planned. Hardware crypto offload is supported in the current driver in main.
 
-GitHub issue: [#72] (https://github.com/FreeBSDFoundation/proj-laptop/issues/72) 
+GitHub issue: [#72](https://github.com/FreeBSDFoundation/proj-laptop/issues/72) 
 
 
 #### Suspend and Resume for LinuxKPI-based Wi-Fi


### PR DESCRIPTION
fixed a malformed link, and removed the link to the roadmap as that was announced in May's report already.

@adventureloop please approve if it looks good to you